### PR TITLE
Patch use of locale.h in `splinefont.h`

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -3,6 +3,7 @@ use alienfile;
 plugin 'PkgConfig' => 'libfontforge';
 
 requires 'Alien::Build::Plugin::Gather::Dino';
+requires 'Path::Tiny' => 0;
 
 # https://fontforge.github.io/
 share {
@@ -18,6 +19,14 @@ share {
 	} else {
 		plugin 'Extract::CommandLine' => $ext;
 	}
+
+	patch sub {
+		my($splinefont_h) = Path::Tiny->new('fontforge/splinefont.h');
+		
+		$splinefont_h->edit_lines(sub {
+			s{\Q#include "locale.h"\E}{#include <locale.h>\n#include <xlocale.h>\n}g;
+		});
+	};
 
 	plugin 'Build::Autoconf' => ();
 

--- a/t/version.t
+++ b/t/version.t
@@ -37,9 +37,6 @@ __DATA__
 
 #undef _
 
-#include <locale.h>
-#include <xlocale.h>
-
 #include "fontforge.h"
 
 const char *


### PR DESCRIPTION
This allows `splinefont.h` to be used on all systems (e.g., `locale_t`
will be defined as expected on macOS).

This removes the need for including `xlocale.h` in the test XS code.
